### PR TITLE
chore(layout-route): cleanup navbar and set TodoItems as default route

### DIFF
--- a/StudentTaskTracker/StudentTaskTracker/App_Start/RouteConfig.cs
+++ b/StudentTaskTracker/StudentTaskTracker/App_Start/RouteConfig.cs
@@ -14,10 +14,13 @@ namespace StudentTaskTracker
             routes.IgnoreRoute("{resource}.axd/{*pathInfo}");
 
             routes.MapRoute(
-                name: "Default",
-                url: "{controller}/{action}/{id}",
-                defaults: new { controller = "Home", action = "Index", id = UrlParameter.Optional }
-            );
+    name: "Default",
+    url: "{controller}/{action}/{id}",
+    defaults: new { controller = "TodoItems", action = "Index", id = UrlParameter.Optional }
+);
+
+
+            
         }
     }
 }

--- a/StudentTaskTracker/StudentTaskTracker/Views/Shared/_Layout.cshtml
+++ b/StudentTaskTracker/StudentTaskTracker/Views/Shared/_Layout.cshtml
@@ -22,9 +22,6 @@
 
             <div class="collapse navbar-collapse" id="mainNavbar">
                 <ul class="navbar-nav ms-auto">
-                    <li class="nav-item">@Html.ActionLink("Home", "Index", "Home", null, new { @class = "nav-link text-white" })</li>
-                    <li class="nav-item">@Html.ActionLink("About", "About", "Home", null, new { @class = "nav-link text-white" })</li>
-                    <li class="nav-item">@Html.ActionLink("Contact", "Contact", "Home", null, new { @class = "nav-link text-white" })</li>
                     <li class="nav-item">@Html.ActionLink("Tasks", "Index", "TodoItems", null, new { @class = "nav-link text-white" })</li>
                 </ul>
             </div>


### PR DESCRIPTION
### Linked issue
#5

### Changes
- Removed unused Home, About, Contact links from navbar
- Updated default route to open TodoItems/Index instead of Home/Index
- Cleaned layout for a more focused user experience

